### PR TITLE
Remove unnecessary urldecode() call

### DIFF
--- a/src/Controller/BilderAltApiController.php
+++ b/src/Controller/BilderAltApiController.php
@@ -48,7 +48,7 @@ class BilderAltApiController extends AbstractController
      */
     public function generateByPath(Request $request): JsonResponse
     {
-        $filePath = urldecode($request->request->get('path', ''));
+        $filePath = $request->request->get('path', '');
         $contextUrl = $request->request->get('contextUrl', '');
 
         if (empty($filePath)) {


### PR DESCRIPTION
I don't think the `urldecode` is necessary here, as the path is in the POST body and is never url encoded.
This causes issues if files contain a `+` for example. The file then can't be found and the image is skipped.