### PR TITLE
Fix Twig error if image doesn't yet have an alt field in the metadata

### DIFF
--- a/src/templates/Backend/bilder_alt_batch_index.html.twig
+++ b/src/templates/Backend/bilder_alt_batch_index.html.twig
@@ -54,7 +54,7 @@
 
                             <td class="alt-text">
                                 {% for meta in file.meta %}
-                                    <p>{{ meta.alt }}</p>
+                                    <p>{{ meta.alt|default }}</p>
                                 {% endfor %}
                             </td>
 


### PR DESCRIPTION
While debugging #9 I stumbled upon this, an image might not yet have the alt field in the meta data, which leads to the following error:

```
Key "alt" for sequence/mapping with keys "title, link, caption" does not exist in @BilderAlt/Backend/bilder_alt_batch_index.html.twig at line 57.
```