### PR TITLE
Fix error in backend files picker related to ambiguous SQL query

### DIFF
--- a/src/classes/BilderAlt.php
+++ b/src/classes/BilderAlt.php
@@ -74,10 +74,11 @@ class BilderAlt
             : [];
 
         if (class_exists(PageModel::class)) {
+            $t = PageModel::getTable();
             $roots = PageModel::findBy(
-                ['type=?', 'published=?'],
+                ["$t.type=?", "$t.published=?"],
                 ['root', '1'],
-                ['order' => 'sorting ASC']
+                ['order' => "$t.sorting ASC"]
             );
             if ($roots !== null) {
                 while ($roots->next()) {


### PR DESCRIPTION
This fixes a problem in the backend files picker which runs SQL query with ambiguous columns:

```sql
SELECT tl_page.*, j1.`id` AS pwChangePage__id, j1.`pid` AS pwChangePage__pid, j1.`sorting` AS pwChangePage__sorting, j1.`tstamp` AS pwChangePage__tstamp, j1.`title` AS pwChangePage__title, j1.`type` AS pwChangePage__type, j1.`alias` AS pwChangePage__alias, j1.`requireItem` AS pwChangePage__requireItem, j1.`routePriority` AS pwChangePage__routePriority, j1.`pageTitle` AS pwChangePage__pageTitle, j1.`language` AS pwChangePage__language, j1.`robots` AS pwChangePage__robots, j1.`description` AS pwChangePage__description, j1.`redirect` AS pwChangePage__redirect, j1.`alwaysForward` AS pwChangePage__alwaysForward, j1.`jumpTo` AS pwChangePage__jumpTo, j1.`redirectBack` AS pwChangePage__redirectBack, j1.`url` AS pwChangePage__url, j1.`target` AS pwChangePage__target, j1.`dns` AS pwChangePage__dns, j1.`staticFiles` AS pwChangePage__staticFiles, j1.`staticPlugins` AS pwChangePage__staticPlugins, j1.`fallback` AS pwChangePage__fallback, j1.`disableLanguageRedirect` AS pwChangePage__disableLanguageRedirect, j1.`favicon` AS pwChangePage__favicon, j1.`robotsTxt` AS pwChangePage__robotsTxt, j1.`maintenanceMode` AS pwChangePage__maintenanceMode, j1.`mailerTransport` AS pwChangePage__mailerTransport, j1.`enableCanonical` AS pwChangePage__enableCanonical, j1.`canonicalLink` AS pwChangePage__canonicalLink, j1.`canonicalKeepParams` AS pwChangePage__canonicalKeepParams, j1.`adminEmail` AS pwChangePage__adminEmail, j1.`dateFormat` AS pwChangePage__dateFormat, j1.`timeFormat` AS pwChangePage__timeFormat, j1.`datimFormat` AS pwChangePage__datimFormat, j1.`validAliasCharacters` AS pwChangePage__validAliasCharacters, j1.`useFolderUrl` AS pwChangePage__useFolderUrl, j1.`urlPrefix` AS pwChangePage__urlPrefix, j1.`urlSuffix` AS pwChangePage__urlSuffix, j1.`useSSL` AS pwChangePage__useSSL, j1.`autoforward` AS pwChangePage__autoforward, j1.`protected` AS pwChangePage__protected, j1.`groups` AS pwChangePage__groups, j1.`includeLayout` AS pwChangePage__includeLayout, j1.`layout` AS pwChangePage__layout, j1.`subpageLayout` AS pwChangePage__subpageLayout, j1.`includeCache` AS pwChangePage__includeCache, j1.`cache` AS pwChangePage__cache, j1.`alwaysLoadFromCache` AS pwChangePage__alwaysLoadFromCache, j1.`clientCache` AS pwChangePage__clientCache, j1.`includeChmod` AS pwChangePage__includeChmod, j1.`cuser` AS pwChangePage__cuser, j1.`cgroup` AS pwChangePage__cgroup, j1.`chmod` AS pwChangePage__chmod, j1.`noSearch` AS pwChangePage__noSearch, j1.`cssClass` AS pwChangePage__cssClass, j1.`sitemap` AS pwChangePage__sitemap, j1.`hide` AS pwChangePage__hide, j1.`guests` AS pwChangePage__guests, j1.`accesskey` AS pwChangePage__accesskey, j1.`published` AS pwChangePage__published, j1.`start` AS pwChangePage__start, j1.`stop` AS pwChangePage__stop, j1.`enforceTwoFactor` AS pwChangePage__enforceTwoFactor, j1.`twoFactorJumpTo` AS pwChangePage__twoFactorJumpTo, j1.`enableCsp` AS pwChangePage__enableCsp, j1.`csp` AS pwChangePage__csp, j1.`cspReportOnly` AS pwChangePage__cspReportOnly, j1.`cspReportLog` AS pwChangePage__cspReportLog, j1.`rootProtection` AS pwChangePage__rootProtection, j1.`rootProtectionUsername` AS pwChangePage__rootProtectionUsername, j1.`rootProtectionPassword` AS pwChangePage__rootProtectionPassword, j1.`activateCookiebar` AS pwChangePage__activateCookiebar, j1.`triggerCookiebar` AS pwChangePage__triggerCookiebar, j1.`prefillCookies` AS pwChangePage__prefillCookies, j1.`overwriteCookiebarMeta` AS pwChangePage__overwriteCookiebarMeta, j1.`cookiebarConfig` AS pwChangePage__cookiebarConfig, j1.`cookiebarDescription` AS pwChangePage__cookiebarDescription, j1.`cookiebarInfoDescription` AS pwChangePage__cookiebarInfoDescription, j1.`cookiebarInfoUrls` AS pwChangePage__cookiebarInfoUrls, j1.`cookiebarExcludePages` AS pwChangePage__cookiebarExcludePages, j1.`cookiebarTemplate` AS pwChangePage__cookiebarTemplate, j1.`cookiebarButtonColorScheme` AS pwChangePage__cookiebarButtonColorScheme, j1.`cookiebarAlignment` AS pwChangePage__cookiebarAlignment, j1.`cookiebarBlocking` AS pwChangePage__cookiebarBlocking, j1.`cookiebarHideOnInit` AS pwChangePage__cookiebarHideOnInit, j1.`pwChangePage` AS pwChangePage__pwChangePage, j1.`newsArchives` AS pwChangePage__newsArchives, j1.`feedFormat` AS pwChangePage__feedFormat, j1.`feedSource` AS pwChangePage__feedSource, j1.`maxFeedItems` AS pwChangePage__maxFeedItems, j1.`feedFeatured` AS pwChangePage__feedFeatured, j1.`feedDescription` AS pwChangePage__feedDescription, j1.`imgSize` AS pwChangePage__imgSize, j1.`languageMain` AS pwChangePage__languageMain, j1.`languageRoot` AS pwChangePage__languageRoot, j1.`languageQuery` AS pwChangePage__languageQuery, j1.`app_socialFacebook` AS pwChangePage__app_socialFacebook, j1.`app_socialLinkedin` AS pwChangePage__app_socialLinkedin, j1.`app_socialInstagram` AS pwChangePage__app_socialInstagram, j1.`app_socialYoutube` AS pwChangePage__app_socialYoutube, j1.`app_socialTiktok` AS pwChangePage__app_socialTiktok, j1.`app_status` AS pwChangePage__app_status, j1.`app_notes` AS pwChangePage__app_notes, j1.`app_navigationImage` AS pwChangePage__app_navigationImage, j1.`app_navigationLevel4Layout` AS pwChangePage__app_navigationLevel4Layout, j1.`app_hideInBreadcrumb` AS pwChangePage__app_hideInBreadcrumb, j1.`app_tabContentPanelTitle` AS pwChangePage__app_tabContentPanelTitle, j1.`app_tabContentPanelDescription` AS pwChangePage__app_tabContentPanelDescription, j1.`app_tabContentPanelIcon` AS pwChangePage__app_tabContentPanelIcon, j1.`app_tabContentPanelIconCustom` AS pwChangePage__app_tabContentPanelIconCustom FROM tl_page LEFT JOIN tl_page j1 ON tl_page.`pwChangePage`=j1.id WHERE type=? AND published=? ORDER BY sorting ASC
```

Error itself:

<img width="2080" height="1536" alt="CleanShot 2026-06-17 at 07 30 54" src="https://github.com/user-attachments/assets/ededc6a4-6b24-4529-9c58-8b06df6d6fc6" />
