### PR TITLE
Also execute batch and pageBatch script on turbo:render

### DIFF
--- a/src/Resources/public/js/batch.js
+++ b/src/Resources/public/js/batch.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', function () {
+function batch() {
     var QUEUE_DELAY_MS = 600;
 
     var batchStartButton = document.getElementById('batch-start');
@@ -230,4 +230,7 @@ document.addEventListener('DOMContentLoaded', function () {
             showNotification('[Bilder Alt] Verarbeitung wird angehalten...', 'info');
         });
     }
-});
+}
+
+document.addEventListener('DOMContentLoaded', batch);
+document.documentElement.addEventListener('turbo:render', batch);

--- a/src/Resources/public/js/seiten_batch.js
+++ b/src/Resources/public/js/seiten_batch.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', function () {
+function pageBatch() {
     var QUEUE_DELAY_MS = 600;
 
     const btnTitle = document.getElementById('batch-generate-title');
@@ -242,4 +242,7 @@ document.addEventListener('DOMContentLoaded', function () {
         shouldStop = true;
         showNotification('[KI Seiten] Verarbeitung wird angehalten...', 'info');
     });
-});
+}
+
+document.addEventListener('DOMContentLoaded', pageBatch);
+document.documentElement.addEventListener('turbo:render', pageBatch);


### PR DESCRIPTION
### Description

Batch and Page_Batch execution do not work within Contao 5.7 due to scripts not being turbo compatible.

The `<main>` block has been changed to become a turbo-frame in Contao 5.7, thus scripts that need initializing need to eihter use a mutation observer, become a stimulus controller, need to be changed to an IIFE or we simply call the function on the `turbo:render` event ☺️.

I wouldn't change the scripts to be stimulus compatible for now to keep 4.13 / 5.3 compatibility.